### PR TITLE
Fix date picker buttons css rule

### DIFF
--- a/projects/date-picker/src/datepicker-buttons/datepicker-buttons.component.scss
+++ b/projects/date-picker/src/datepicker-buttons/datepicker-buttons.component.scss
@@ -27,7 +27,7 @@ ngx-datepicker-buttons {
     font-size: inherit;
 
     ngx-datepicker-buttons {
-        .mat-mdc-icon-button {
+        .mat-mdc-icon-button.mat-mdc-button-base {
             font-size: 130%;
             padding: 0;
         }


### PR DESCRIPTION
fix(datePickerButtons): target more precisely the button using css to avoid precedence errors