### PR TITLE
feat(guards): chainActivateGuards & chainMatchGuards (NGXCPTS-55)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
                 "@angular/material": "~21.2.14",
                 "@angular/material-date-fns-adapter": "~21.2.14",
                 "@angular/platform-browser-dynamic": "~21.2.17",
+                "@angular/router": "~21.2.17",
                 "@commitlint/cli": "~20.3.1",
                 "@commitlint/config-conventional": "~20.3.1",
                 "@hug/eslint-config": "~20.3.3",
@@ -1339,6 +1340,24 @@
                 "@angular/compiler": "21.2.17",
                 "@angular/core": "21.2.17",
                 "@angular/platform-browser": "21.2.17"
+            }
+        },
+        "node_modules/@angular/router": {
+            "version": "21.2.17",
+            "resolved": "https://registry.npmjs.org/@angular/router/-/router-21.2.17.tgz",
+            "integrity": "sha512-RSCtK5ppAV6y6wfRLHSK2a9Wc/vm8j0wsC+/j9PH9yQmppWFVXDWsg5E39MKOIpnoYVx2+hI6eak6+wYtZTe1A==",
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.3.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            },
+            "peerDependencies": {
+                "@angular/common": "21.2.17",
+                "@angular/core": "21.2.17",
+                "@angular/platform-browser": "21.2.17",
+                "rxjs": "^6.5.3 || ^7.4.0"
             }
         },
         "node_modules/@arr/every": {
@@ -26936,6 +26955,7 @@
                 "@angular/common": ">=21 <22",
                 "@angular/core": ">=21 <22",
                 "@angular/material": ">=21 <22",
+                "@angular/router": ">=21 <22",
                 "@fontsource-variable/material-symbols-outlined": ">= 5.0.41",
                 "@fontsource/material-icons": ">= 4.5.4",
                 "@fontsource/roboto": ">= 4.5.8",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
         "@angular/material": "~21.2.14",
         "@angular/material-date-fns-adapter": "~21.2.14",
         "@angular/platform-browser-dynamic": "~21.2.17",
+        "@angular/router": "~21.2.17",
         "@commitlint/cli": "~20.3.1",
         "@commitlint/config-conventional": "~20.3.1",
         "@hug/eslint-config": "~20.3.3",

--- a/projects/core/package.json
+++ b/projects/core/package.json
@@ -57,6 +57,7 @@
         "@angular/common": ">=21 <22",
         "@angular/core": ">=21 <22",
         "@angular/material": ">=21 <22",
+        "@angular/router": ">=21 <22",
         "@fontsource-variable/material-symbols-outlined": ">= 5.0.41",
         "@fontsource/material-icons": ">= 4.5.4",
         "@fontsource/roboto": ">= 4.5.8",

--- a/projects/core/src/guards/guard.util.ts
+++ b/projects/core/src/guards/guard.util.ts
@@ -1,0 +1,39 @@
+import { inject, Injector, runInInjectionContext } from '@angular/core';
+import type { ActivatedRouteSnapshot, CanActivateFn, CanMatchFn, GuardResult, MaybeAsync, Route, RouterStateSnapshot, UrlSegment } from '@angular/router';
+import { from, isObservable, type Observable, of, switchMap } from 'rxjs';
+
+/**
+ * @param guards the guards
+ * @returns the chained results of the guards until first condition is not met
+ */
+export const chainActivateGuards = (...guards: CanActivateFn[]): CanActivateFn => (route: ActivatedRouteSnapshot, state: RouterStateSnapshot): MaybeAsync<GuardResult> => chainGuards$(guard$ => guard$(route, state), guards);
+
+/**
+ * run sequentially the guards until one condition is not met
+ * @param guards the guards
+ * @returns the chained results of the guards until first condition is not met
+ */
+export const chainMatchGuards = (...guards: CanMatchFn[]): CanMatchFn => (route: Route, segments: UrlSegment[]): MaybeAsync<GuardResult> => chainGuards$(guard$ => guard$(route, segments), guards);
+
+/**
+ * @param applyGuard$ result of previous guard
+ * @param guards the guards to apply
+ * @returns the chained results of the guards until first condition is not met
+ */
+const chainGuards$ = <T>(applyGuard$: (guard: T) => MaybeAsync<GuardResult>, guards: T[]): MaybeAsync<GuardResult> => {
+    const injectionContext = inject(Injector);
+    return guards.reduce((acc$: Observable<GuardResult>, guard) => acc$.pipe(switchMap(result => result
+        ? runInInjectionContext(injectionContext, () => toObservable$(applyGuard$(guard)))
+        : of(result))), of(true));
+};
+
+/**
+ * @param input$ maybe asyncs to convert to observables
+ * @returns an observable
+ */
+const toObservable$ = <T>(input$: MaybeAsync<T>): Observable<T> => {
+    if (isObservable(input$)) {
+        return input$;
+    }
+    return input$ instanceof Promise ? from(input$) : of(input$);
+};

--- a/projects/core/src/guards/index.ts
+++ b/projects/core/src/guards/index.ts
@@ -1,0 +1,1 @@
+export { chainActivateGuards, chainMatchGuards } from './guard.util';

--- a/projects/core/src/index.ts
+++ b/projects/core/src/index.ts
@@ -4,6 +4,7 @@ export * from './directives/single-click.directive';
 export * from './cache';
 export * from './custom-operators';
 export * from './custom-array.module';
+export * from './guards';
 export * from './key-codes';
 export * from './providers';
 export * from './pipes';

--- a/projects/core/src/providers/date-format.provider.spec.ts
+++ b/projects/core/src/providers/date-format.provider.spec.ts
@@ -82,7 +82,7 @@ describe('NgxDateFormatProvider', () => {
 
         isEqualsTo(factory, localeFrCh, standardExpected);
         isEqualsTo(factory, localeItCh, englishExpected);
-        isEqualsTo(factory, localeDeCh, standardExpected);
+        isEqualsTo(factory, localeDeCh, englishExpected);
         isEqualsTo(factory, localeEnUs, englishExpected);
         isEqualsTo(factory, localeEs, {
             parse: {


### PR DESCRIPTION
Fonctions chainActivateGuards et chainMatchGuards permettant de chainer des guards sur le routage d’une page.

Afin de ne pas exécuter des fonctions qui pourraient effectuer des appels HTTP alors que l’accès à la page est invalidé par une autre condition.

Par exemple, dans cette chaine:

`canActivate: [chainActivateGuards(canActivate1$, canActivate2$, canActivate3$)],`

Si canActivate1$ renvoie true, on exécute canActivate2$.
Si canActivate2$ renvoie false,  canActivate3$ ne sera pas exécutéee.